### PR TITLE
Update copyright year for 2021

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,7 +574,7 @@ class="placement col-xs-12 col-sm-4"
               Website by <a href="https://kerrisharp.com" target="_blank">Kerri Sharp</a>.
             </p>
             <p>
-              &copy; 2020 <a href="https://portmanteauagency.com">Portmanteau Agency</a>.
+              &copy; 2021 <a href="https://portmanteauagency.com">Portmanteau Agency</a>.
             </p>
           </div>
           <div class="col-xs-12 col-sm-6">


### PR DESCRIPTION
Very simple PR - updates the copyright year quoted in the footer:

![image](https://user-images.githubusercontent.com/10532380/105522570-55128a80-5cd5-11eb-94bd-a3e4ae89c8a8.png)
